### PR TITLE
Fix: [NO-ISSUE] Config 모듈 전역으로 사용 가능하도록 수정

### DIFF
--- a/libs/config/src/config.module.ts
+++ b/libs/config/src/config.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { ConfigModule as NestConfigModule } from '@nestjs/config';
 import { ConfigService } from './config.service';
 
@@ -6,6 +6,7 @@ const NestConfigDynamicModule = NestConfigModule.forRoot({
   envFilePath: ['.env.local', '.env'],
 });
 
+@Global()
 @Module({
   imports: [NestConfigDynamicModule],
   providers: [ConfigService],


### PR DESCRIPTION
# Link

- 이슈 티켓 생략

# Summary

- ConfigModule을 AppModule 하위의 전역에서 사용하도록 수정

# ETC

- ConfigModule을 AppModule 하위의 모듈에서 사용하려면 해당 모듈에 ConfigModule을 `import`해야 한다.
- 전역 모듈화 하면 하위 모듈에서 `import` 없이 `ConfigService`만 DI하여 사용하면 된다.


# Before I request PR review

(내가 PR 리뷰 부탁하기 전에 한 일)

# After this PR reviewed

(PR 리뷰가 끝난다면 뭘 해야 하는가? Merge 전 필요한 Process들)

# Expected due date

(희망 리뷰 완료일, 최소기준 : 배포 3일 전까지)
6/13