### PR TITLE
Feat: [SISO-55] 샘플(Notes) 컨트롤러 및 서비스 레이어 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^2.1.0",
     "@nestjs/core": "^8.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^8.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { ConfigModule } from '@config/config';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { NotesModule } from './notes/notes.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, NotesModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/notes/fixtures/notes.ts
+++ b/src/notes/fixtures/notes.ts
@@ -1,0 +1,17 @@
+import { Note } from 'src/notes/interfaces/notes';
+
+let seq = 0;
+const getNextSeq = (): number => ++seq;
+
+export const notes: Note[] = [
+  {
+    id: getNextSeq(),
+    title: 'First note',
+    content: 'This is the first note',
+  },
+  {
+    id: getNextSeq(),
+    title: 'Second note',
+    content: 'No contents',
+  },
+];

--- a/src/notes/interfaces/notes.d.ts
+++ b/src/notes/interfaces/notes.d.ts
@@ -1,0 +1,5 @@
+export interface Note {
+  id: number;
+  title: string;
+  content: string;
+}

--- a/src/notes/notes.controller.spec.ts
+++ b/src/notes/notes.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotesController } from './notes.controller';
+import { NotesService } from './notes.service';
+
+describe('NotesController', () => {
+  let controller: NotesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotesController],
+      providers: [NotesService],
+    }).compile();
+
+    controller = module.get<NotesController>(NotesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/notes/notes.controller.ts
+++ b/src/notes/notes.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { NotesService } from './notes.service';
+
+@Controller('notes')
+export class NotesController {
+  constructor(private readonly notesService: NotesService) {}
+}

--- a/src/notes/notes.controller.ts
+++ b/src/notes/notes.controller.ts
@@ -1,7 +1,34 @@
-import { Controller } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+} from '@nestjs/common';
+import { Note } from './interfaces/notes';
 import { NotesService } from './notes.service';
 
 @Controller('notes')
 export class NotesController {
   constructor(private readonly notesService: NotesService) {}
+
+  @Get()
+  async findAll(): Promise<Note[]> {
+    return this.notesService.findAll();
+  }
+
+  @Get(':id')
+  async findById(@Param('id') _id: string): Promise<Note> {
+    const id = parseInt(_id);
+    if (isNaN(id)) {
+      throw new BadRequestException(
+        `Invalid value for id of path parameter: "${_id}"`,
+      );
+    }
+    const note = await this.notesService.findById(id);
+    if (!note) {
+      throw new NotFoundException(`There is no note with id ${id}`);
+    }
+    return note;
+  }
 }

--- a/src/notes/notes.module.ts
+++ b/src/notes/notes.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { NotesService } from './notes.service';
+import { NotesController } from './notes.controller';
+
+@Module({
+  controllers: [NotesController],
+  providers: [NotesService],
+})
+export class NotesModule {}

--- a/src/notes/notes.service.spec.ts
+++ b/src/notes/notes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotesService } from './notes.service';
+
+describe('NotesService', () => {
+  let service: NotesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [NotesService],
+    }).compile();
+
+    service = module.get<NotesService>(NotesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NotesService {}

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -1,4 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { notes } from 'src/notes/fixtures/notes';
+import { Note } from 'src/notes/interfaces/notes';
 
 @Injectable()
-export class NotesService {}
+export class NotesService {
+  async findAll(): Promise<Note[]> {
+    return notes;
+  }
+
+  async findById(id: number): Promise<Note | null> {
+    return notes.find((note) => note.id === id) ?? null;
+  }
+}

--- a/src/types/utils.d.ts
+++ b/src/types/utils.d.ts
@@ -1,0 +1,4 @@
+/** 객체, 배열의 값의 타입만 추출하는 제너릭 타입 함수 */
+export type ValueOf<T> = T extends ReadonlyArray<infer ElementType>
+  ? ElementType
+  : T[keyof T];

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,11 @@
     tslib "2.4.0"
     uuid "8.3.2"
 
+"@nestjs/mapped-types@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz#78b62041c7a407db4a90eb140567321602bed18e"
+  integrity sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==
+
 "@nestjs/platform-express@^8.0.0":
   version "8.4.5"
   resolved "https://registry.yarnpkg.com/@nestjs/platform-express/-/platform-express-8.4.5.tgz#5683da37b4e5463a4f26e78cb5fb1ba75e94440c"


### PR DESCRIPTION
# Link

- Jira Issue Ticket: https://teamtuesday.atlassian.net/browse/SISO-55
- Techspec: https://teamtuesday.atlassian.net/l/c/AFMr2391

# Summary

- 샘플 컨트롤러 및 서비스 레이어 추가

(내가 뭘 했는지 : 작업에 대한 설명, 기존코드와 변경점 등)

# ETC

- yarn nest generate resource notes 실행 (REST API, No CRUD)
- package-lock.json 삭제 및 yarn.lock의 registry 변경 이슈 수정(yarnpkg.com으로 유지되도록)
- `notes.controller.ts`, `notes.service.ts` 파일에 notes 제공 로직 추가
  - `fixtures` 폴더는 nest 컴포넌트와 관계 없는 폴더(샘플 리소스를 제공하기 위한 파일)
  - `interfaces` 폴더는 모듈 내 타입 정의를 작성한다. DB 등이 추가되면 `dto`, `entities`와 같이 사용되면 좋을 듯.

(PR에 대한 추가 설명 혹은 작업시 고민되었던 부분)

# Before I request PR review

- 서버 실행 후 간단 테스트

```sh
# List notes
curl localhost:8080/notes

# Get a note that has id 1
curl localhost:8080/notes/1
```

(내가 PR 리뷰 부탁하기 전에 한 일)

# After this PR reviewed

(PR 리뷰가 끝난다면 뭘 해야 하는가? Merge 전 필요한 Process들)

# Expected due date

(희망 리뷰 완료일, 최소기준 : 배포 3일 전까지)
6/13