### PR TITLE
fix: [NO-ISSUE] CODEOWNERS 내 멤버 참조를 팀으로 지정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # docs for CODEOWNERS, https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # All files for members of siso-backend
-* @sua-no @Jangyusu @hoontae24
+* @TeamTuesday/siso-backend
 


### PR DESCRIPTION
# Link

- None

# Summary

- CODEOWNERS 내 멤버 참조를 팀으로 지정

